### PR TITLE
Fix Kassa#receipt customer_receipt attribute validation

### DIFF
--- a/lib/cloud_payments/namespaces/kassa.rb
+++ b/lib/cloud_payments/namespaces/kassa.rb
@@ -13,7 +13,7 @@ module CloudPayments
       def receipt(attributes)
         attributes.fetch(:inn)  { raise InnNotProvided.new('inn attribute is required') }
         attributes.fetch(:type) { raise TypeNotProvided.new('type attribute is required') }
-        attributes.fetch(:inn)  { raise CustomerReceiptNotProvided.new('customer_receipt is required') }
+        attributes.fetch(:customer_receipt)  { raise CustomerReceiptNotProvided.new('customer_receipt is required') }
 
         request(:receipt, attributes)
       end

--- a/spec/cloud_payments/namespaces/kassa_spec.rb
+++ b/spec/cloud_payments/namespaces/kassa_spec.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe CloudPayments::Namespaces::Kassa do
+  subject{ described_class.new(CloudPayments.client) }
+
+  describe '#receipt' do
+    let(:attributes) do
+      {
+        inn: '7708806666',
+        type: 'Income',
+        customer_receipt:  {
+          items: [
+            {
+              amount: '13350.00',
+              label: 'Good Description',
+              price: '13350.00',
+              quantity: 1.0,
+              vat: 0
+            }
+          ]
+        }
+      }
+    end
+
+    context do
+      before{ attributes.delete(:inn) }
+      specify{ expect{subject.receipt(attributes)}.to raise_error(described_class::InnNotProvided) }
+    end
+
+    context do
+      before{ attributes.delete(:type) }
+      specify{ expect{subject.receipt(attributes)}.to raise_error(described_class::TypeNotProvided) }
+    end
+
+    context do
+      before{ attributes.delete(:customer_receipt) }
+      specify{ expect{subject.receipt(attributes)}.to raise_error(described_class::CustomerReceiptNotProvided) }
+    end
+  end
+end


### PR DESCRIPTION
Fixes a typo in Kassa namespace that inproperly validated inn instead of customer_receipt attribute. Also adds specs for attributes validation. 