### PR TITLE
Faraday::Connection#basic_auth is deprecated

### DIFF
--- a/cloud_payments.gemspec
+++ b/cloud_payments.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '< 2.0'
   spec.add_dependency 'multi_json', '~> 1.11'
   spec.add_dependency 'hashie', '~> 3.4'
 

--- a/lib/cloud_payments/client.rb
+++ b/lib/cloud_payments/client.rb
@@ -16,7 +16,6 @@ module CloudPayments
     end
 
     def perform_request(path, params = nil)
-      connection.basic_auth(config.public_key, config.secret_key)
       response = connection.post(path, (params ? convert_to_json(params) : nil), headers)
 
       Response.new(response.status, response.body, response.headers).tap do |response|
@@ -45,7 +44,10 @@ module CloudPayments
     end
 
     def build_connection
-      Faraday::Connection.new(config.host, config.connection_options, &config.connection_block)
+      Faraday::Connection.new(config.host, config.connection_options) do |conn|
+        conn.request :basic_auth, config.public_key, config.secret_key
+        config.connection_block.call(conn) if config.connection_block
+      end
     end
   end
 end


### PR DESCRIPTION
In faraday 1.8 `basic_auth` method was deprecated. They recommend
use request middleware.

The deprecation message is:

    WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
    While initializing your connection, use `#request(:basic_auth, ...)` instead.
    See https://lostisland.github.io/faraday/middleware/authentication for more usage info.

I also added a version restriction to faraday in gemspec. It seems that
faraday 2.0 may not be compatible with cloud_payments gem.