### PR TITLE
Reset client after each test

### DIFF
--- a/spec/cloud_payments_spec.rb
+++ b/spec/cloud_payments_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 
 describe CloudPayments do
   describe '#config=' do
-    before { @old_config = CloudPayments.config }
-    after { CloudPayments.config = @old_config }
-
     specify{ expect{ CloudPayments.config = 'config' }.to change{ CloudPayments.config }.to('config') }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,13 +15,22 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.include CloudPayments::RSpec::Helpers
 
-  config.before :each do
-    CloudPayments.configure do |c|
+  # these params are used in stubs, in basic auth
+  # see webmock_stub in spec/support/helpers.rb
+  def default_config
+    CloudPayments::Config.new do |c|
       c.public_key = 'user'
       c.secret_key = 'pass'
       c.host = 'http://localhost:9292'
       c.log = false
       # c.raise_banking_errors = true
     end
+  end
+
+  CloudPayments.config = default_config
+
+  config.after :each do
+    CloudPayments.config = default_config
+    CloudPayments.client = CloudPayments::Client.new
   end
 end


### PR DESCRIPTION
CloudPayments::Config and CloudPayments::Client both are mutable and
also memoized. Some tests mutate config and may break stubbed requests.

WebMock stubs assume that the client is configured with "default config"
in spec_helper.

One may run rspec with `--seed 58378` to get failing tests (before this commit).