### PR TITLE
Replace `File.exists?` with `File.exist?`

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -73,7 +73,7 @@ module CloudPayments
         def fixture
           @fixture ||= begin
             file = fixture_path.join("#{name}.yml").to_s
-            YAML.load(File.read(file)) if File.exists?(file)
+            YAML.load(File.read(file)) if File.exist?(file)
           end
         end
 


### PR DESCRIPTION
`File.exists?` method was removed in ruby 3.2

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/