### PR TITLE
Support faraday 2+

### DIFF
--- a/cloud_payments.gemspec
+++ b/cloud_payments.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '< 2.0'
+  spec.add_dependency 'faraday', '< 3.0'
   spec.add_dependency 'multi_json', '~> 1.11'
   spec.add_dependency 'hashie', '~> 3.4'
 

--- a/lib/cloud_payments/client.rb
+++ b/lib/cloud_payments/client.rb
@@ -45,7 +45,15 @@ module CloudPayments
 
     def build_connection
       Faraday::Connection.new(config.host, config.connection_options) do |conn|
-        conn.request :basic_auth, config.public_key, config.secret_key
+
+        # https://github.com/lostisland/faraday/blob/main/UPGRADING.md#authentication-helper-methods-in-connection-have-been-removed
+        # https://lostisland.github.io/faraday/#/middleware/included/authentication?id=faraday-1x-usage
+        if Faraday::VERSION.start_with?("1.")
+          conn.request :basic_auth, config.public_key, config.secret_key
+        else
+          conn.request :authorization, :basic, config.public_key, config.secret_key
+        end
+
         config.connection_block.call(conn) if config.connection_block
       end
     end


### PR DESCRIPTION
Use new authentication helper for basic auth with faraday >= 2.
Support both 1.* and 2.* versions of the faraday gem.